### PR TITLE
fix: runs against local helia

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -465,3 +465,4 @@ analysis/plots/*.png
 
 db.toml
 /udgerdb_v3.dat
+.envrc

--- a/README.md
+++ b/README.md
@@ -327,7 +327,7 @@ An alternative IPFS implementation needs to support a couple of things:
 
 ## Contributing
 
-Feel free to dive in! [Open an issue](https://github.com/RichardLitt/standard-readme/issues/new) or submit PRs.
+Feel free to dive in! [Open an issue](https://github.com/plprobelab/tiros/issues/new) or submit PRs.
 
 ## License
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.9"
 name: tiros
 services:
   ipfs:
-    image: helia:latest
+    image: helia-http-gateway:latest
     restart: unless-stopped
     volumes:
       - ipfs_path:/data/ipfs
@@ -11,7 +11,7 @@ services:
     environment:
       DEBUG: helia-server
     ports:
-      - "0.0.0.0:8080:8080"
+      - "0.0.0.0:${HELIA_PORT:-8080}:8080"
   chrome:
     image: browserless/chrome:latest
     ports:
@@ -19,7 +19,7 @@ services:
   db:
     image: postgres:14
     ports:
-      - "0.0.0.0:5432:5432"
+      - "0.0.0.0:${TIROS_RUN_DATABASE_PORT:-5432}:5432"
     environment:
       POSTGRES_PASSWORD: password
       POSTGRES_USER: tiros_test


### PR DESCRIPTION
Things I've noted during local runs:

1. healthcheck was failing locally due to no `/` on helia-http-gateway (fixed on latest)
1. `go-ipfs-api` requests to helia-http-gateway via `t.ipfs.Version` don't work for some reason..  
    * Needs investigation.. should just be HTTP request, but it isn't. This PR works (change .Version to raw http request fixes version check
1. http request to `http://localhost:8888/ipns/filecoin.io` fails with error: 
    * `error="error value: &rod.ErrNavigation{Reason:\"net::ERR_CONNECTION_REFUSED\"}\ngoroutine 61 [running]:\nruntime/debug.Stack()\n\t/Users/sgtpooki/.asdf/installs/golang/1.21.3/go/src/runtime/debug/stack.go:24 +0x64\ngithub.com/go-rod/rod.Try.func1()\n\t/Users/sgtpooki/.asdf/installs/golang/1.21.3/packages/pkg/mod/github.com/go-rod/rod@v0.112.6/utils.go:213 +0x3c\npanic({0x102f6c000?, 0x14000590c80?})\n\t/Users/sgtpooki/.asdf/installs/golang/1.21.3/go/src/runtime/panic.go:914 +0x218\nmain.(*probe).mustNavigate(0x140001e5680)\n\t/Users/sgtpooki/code/work/protocol.ai/plprobelab/tiros/probe.go:235 +0x634\nmain.(*probe).run.func1()\n\t/Users/sgtpooki/code/work/protocol.ai/plprobelab/tiros/probe.go:156 +0x2c\ngithub.com/go-rod/rod.Try(0x140001e5680?)\n\t/Users/sgtpooki/.asdf/installs/golang/1.21.3/packages/pkg/mod/github.com/go-rod/rod@v0.112.6/utils.go:217 +0x58\nmain.(*probe).run(0x140001e5680)\n\t/Users/sgtpooki/code/work/protocol.ai/plprobelab/tiros/probe.go:154 +0x80\nmain.(*tiros).measureWebsites(0x14000514360, 0x1400041c280, {0x140001c8690, 0x1, 0x1?}, 0x14000043500)\n\t/Users/sgtpooki/code/work/protocol.ai/plprobelab/tiros/probe.go:49 +0x2b0\ncreated by main.RunAction in goroutine 1\n\t/Users/sgtpooki/code/work/protocol.ai/plprobelab/tiros/cmd_run.go:219 +0x830\n" url="http://localhost:8888/ipns/filecoin.io"`
5. 