### PR TITLE
feat: add inbrowser.link to tiros

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -6,12 +6,13 @@ export TIROS_RUN_DATABASE_PORT=5432
 export TIROS_RUN_DATABASE_SSL_MODE=disable
 export TIROS_RUN_DATABASE_USER=tiros_test
 export TIROS_RUN_KUBO_API_PORT=5001
-export TIROS_RUN_KUBO_HOST=ipfs
+export TIROS_RUN_IPFS_HOST=inbrowser.link
+export TIROS_RUN_IPFS_GATEWAY_PORT=443
 export TIROS_RUN_LOOKUP_PROVIDERS=false
 export TIROS_RUN_REGION=local
 export TIROS_IPFS_IMPLEMENTATION=KUBO
 export TIROS_RUN_SETTLE_TIMES=10 # <- set the first 1 to something larger to wait x number of seconds before the first request is made
 export TIROS_RUN_TIMES=1
-export TIROS_RUN_WEBSITES=filecoin.io # <- you can add comma separated values here
+export TIROS_RUN_WEBSITES=specs.ipfs.tech # <- you can add comma separated values here
 export TIROS_UDGER_DB_PATH=./udgerdb_v3.dat # can be left blank if you don't have the DB handy
-
+export TIROS_RUN_SERVICE_WORKER=true

--- a/cmd_run.go
+++ b/cmd_run.go
@@ -137,6 +137,12 @@ var RunCommand = &cli.Command{
 			EnvVars: []string{"TIROS_RUN_TIMEOUT"},
 			Value:   time.Duration(0),
 		},
+		&cli.BoolFlag{
+			Name:    "service-worker",
+			Usage:   "Whether to check for service worker registration",
+			EnvVars: []string{"TIROS_RUN_SERVICE_WORKER"},
+			Value:   false,
+		},
 	},
 	Action: RunAction,
 }

--- a/js.go
+++ b/js.go
@@ -8,6 +8,9 @@ import (
 //go:embed js/tti-polyfill.js
 var jsTTIPolyfill string
 
+//go:embed js/check-service-worker-registered.js
+var jsCheckServiceWorkerRegistered string
+
 //go:embed js/web-vitals.iife.js
 var jsWebVitalsIIFE string
 

--- a/js/check-service-worker-registered.js
+++ b/js/check-service-worker-registered.js
@@ -1,0 +1,17 @@
+(() => {
+  if ('serviceWorker' in navigator) {
+    navigator.serviceWorker.getRegistration()
+      .then((registration) => {
+        if (registration) {
+          console.log('Service worker registered');
+        } else {
+          console.log('Service worker not registered');
+        }
+      })
+      .catch((error) => {
+        console.error('Error getting service worker registration:', error);
+      });
+  } else {
+    console.log('Service worker not supported');
+  }
+})();


### PR DESCRIPTION
FYI that this work is in progress. I don't think the measurements are correct.

I will likely need some help with figuring out how we can start the measurements from the very first time `inbrowser.link/ipns/{site}` is hit.

I'm hoping that it doesn't require a large change to the current probe logic, but I feel like it might.
